### PR TITLE
Add functions and tests for filter methods information gain 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,11 @@ Authors@R: c(
 Description: What the package does (one paragraph).
 License: MIT + file LICENSE
 Suggests: 
+    aorsf,
+    FSelectorRcpp,
     modeldata,
+    partykit,
+    ranger,
     testthat (>= 3.0.0),
     titanic
 Config/testthat/edition: 3
@@ -21,14 +25,11 @@ RoxygenNote: 7.3.2
 URL: https://github.com/tidymodels/filters
 BugReports: https://github.com/tidymodels/filters/issues
 Imports: 
-    aorsf,
     cli,
     dplyr,
     glue,
-    partykit,
     pROC,
     purrr,
-    ranger,
     rlang,
     stats,
     tibble,

--- a/R/score-cor.R
+++ b/R/score-cor.R
@@ -20,7 +20,7 @@ score_cor <- function(
     tuning = FALSE,
     ties = NULL,
     calculating_fn = get_single_pearson,
-    label = c(score_aov = "Correlation scores")
+    label = c(score_cor = "Correlation scores")
   )
 }
 

--- a/R/score-cross_tab.R
+++ b/R/score-cross_tab.R
@@ -20,7 +20,7 @@ score_cross_tab <- function(
     tuning = FALSE,
     ties = NULL,
     calculating_fn = get_single_chisq,
-    label = c(score_aov = "Cross tabulation p-values")
+    label = c(score_crosstab = "Cross tabulation p-values")
   )
 }
 

--- a/R/score-forest_imp.R
+++ b/R/score-forest_imp.R
@@ -20,7 +20,7 @@ score_forest_imp <- function(
     tuning = TRUE,
     ties = NULL,
     calculating_fn = NULL,
-    label = c(score_aov = "Random Forest importance scores")
+    label = c(score_rfimp = "Random Forest importance scores")
   )
 }
 
@@ -30,7 +30,7 @@ get_imp_rf_ranger <- function(score_obj, data, outcome) {
   fit <- ranger::ranger(
     x = X,
     y = y,
-    data = data,
+    #data = data,
     num.trees = score_obj$trees,
     mtry = score_obj$mtry,
     importance = score_obj$score_type, # TODO importance = c(impurity)

--- a/R/score-info_gain.R
+++ b/R/score-info_gain.R
@@ -1,0 +1,60 @@
+score_info_gain <- function(
+  range = c(0, Inf),
+  trans = NULL,
+  score_type = "infogain",
+  direction = "maximize"
+) {
+  new_score_obj(
+    subclass = c("any"),
+    outcome_type = c("numeric", "factor"),
+    predictor_type = c("numeric", "factor"),
+    case_weights = FALSE, # TODO
+    range = range,
+    inclusive = c(TRUE, TRUE),
+    fallback_value = Inf,
+    score_type = score_type, # c("infogain", "gainratio", "symuncert"),
+    trans = NULL, # TODO
+    sorts = NULL, # TODO
+    direction = c("maximize", "minimize", "target"),
+    deterministic = TRUE,
+    tuning = FALSE,
+    ties = NULL,
+    calculating_fn = NULL,
+    label = c(score_infogain = "Information Gain scores")
+  )
+}
+
+make_scores_info_gain <- function(
+  score_type,
+  fit,
+  outcome
+) {
+  res <- dplyr::tibble(
+    name = score_type,
+    score = fit$importance,
+    outcome = outcome,
+    predictor = fit$attributes
+  )
+  res
+}
+
+get_scores_info_gain <- function(
+  score_obj,
+  data,
+  outcome,
+  ...
+) {
+  predictors <- setdiff(names(data), outcome)
+
+  y <- data[[outcome]]
+  X <- data[setdiff(names(data), outcome)]
+
+  fit <- FSelectorRcpp::information_gain(
+    x = X,
+    y = y,
+    type = "infogain", # TODO
+    equal = score_obj$equal # Set = TRUE for numeric outcome
+  )
+  res <- make_scores_info_gain(score_obj$score_type, fit, outcome)
+  res
+}

--- a/R/score-info_gain.R
+++ b/R/score-info_gain.R
@@ -44,8 +44,6 @@ get_scores_info_gain <- function(
   outcome,
   ...
 ) {
-  predictors <- setdiff(names(data), outcome)
-
   y <- data[[outcome]]
   X <- data[setdiff(names(data), outcome)]
 

--- a/R/score-roc_auc.R
+++ b/R/score-roc_auc.R
@@ -24,7 +24,7 @@ score_roc_auc <- function(range = c(0, 1), trans = NULL) {
     tuning = FALSE,
     ties = NULL,
     calculating_fn = get_single_roc_auc,
-    label = c(score_aov = "ROC AUC scores")
+    label = c(score_rocauc = "ROC AUC scores")
   )
 }
 

--- a/tests/testthat/test-score-aov.R
+++ b/tests/testthat/test-score-aov.R
@@ -1,14 +1,15 @@
 test_that("get_scores_aov() is working", {
   skip_if_not_installed("modeldata")
   data(ames, package = "modeldata")
-  data <- tibble::tibble(
-    Sale_Price = ames$Sale_Price,
-    MS_SubClass = ames$MS_SubClass,
-    MS_Zoning = ames$MS_Zoning,
-    Lot_Frontage = ames$Lot_Frontage,
-    Lot_Area = ames$Lot_Area,
-    Street = ames$Street,
-  )
+  data <- modeldata::ames |>
+    dplyr::select(
+      Sale_Price,
+      MS_SubClass,
+      MS_Zoning,
+      Lot_Frontage,
+      Lot_Area,
+      Street
+    )
   outcome <- "Sale_Price"
   score_obj = score_aov()
   score_res <- get_scores_aov(score_obj, data, outcome)

--- a/tests/testthat/test-score-forest_imp.R
+++ b/tests/testthat/test-score-forest_imp.R
@@ -20,10 +20,12 @@ test_that("get_score_forest_importance() is working for ranger for classificatio
   set.seed(42)
   score_res <- get_scores_forest_importance(score_obj, data, outcome)
 
+  y <- data[[outcome]]
+  X <- data[setdiff(names(data), outcome)]
   set.seed(42)
   fit <- ranger::ranger(
-    formula = class ~ .,
-    data = data,
+    y = y,
+    x = X,
     num.trees = 10,
     mtry = 2,
     importance = "permutation",
@@ -72,9 +74,8 @@ test_that("get_score_forest_importance() is working for ranger regression", {
   y <- data[[outcome]]
   X <- data[setdiff(names(data), outcome)]
   fit <- ranger::ranger(
-    x = X, # Remove formula = Sale_Price ~ .,
+    x = X,
     y = y,
-    data = data,
     num.trees = 10,
     mtry = 2,
     importance = "permutation",

--- a/tests/testthat/test-score-info_gain.R
+++ b/tests/testthat/test-score-info_gain.R
@@ -1,4 +1,37 @@
-# TODO Test for classification
+test_that("get_scores_info_gain() is working for classification", {
+  skip_if_not_installed("modeldata")
+  data(cells, package = "modeldata")
+  data <- modeldata::cells |>
+    dplyr::select(
+      case,
+      class,
+      angle_ch_1,
+      area_ch_1,
+      avg_inten_ch_1,
+      avg_inten_ch_2
+    )
+  outcome <- "class"
+  score_obj <- score_info_gain()
+  score_obj$equal <- FALSE # Default
+  score_res <- get_scores_info_gain(score_obj, data, outcome)
+
+  y <- data[[outcome]]
+  X <- data[setdiff(names(data), outcome)]
+  fit <- FSelectorRcpp::information_gain(x = X, y = y)
+  exp.res <- fit$importance
+
+  expect_true(tibble::is_tibble(score_res))
+
+  expect_identical(nrow(score_res), ncol(data) - 1L)
+
+  expect_named(score_res, c("name", "score", "outcome", "predictor"))
+
+  expect_identical(score_res$score, exp.res)
+
+  expect_equal(unique(score_res$name), "infogain")
+
+  expect_equal(unique(score_res$outcome), "class")
+})
 
 test_that("get_scores_info_gain() is working for regression", {
   skip_if_not_installed("modeldata")

--- a/tests/testthat/test-score-info_gain.R
+++ b/tests/testthat/test-score-info_gain.R
@@ -1,0 +1,38 @@
+# TODO Test for classification
+
+test_that("get_scores_info_gain() is working for regression", {
+  skip_if_not_installed("modeldata")
+  data(ames, package = "modeldata")
+  data <- modeldata::ames |>
+    dplyr::select(
+      Sale_Price,
+      MS_SubClass,
+      MS_Zoning,
+      Lot_Frontage,
+      Lot_Area,
+      Street
+    )
+  outcome <- "Sale_Price"
+  score_obj <- score_info_gain()
+  score_obj$equal <- TRUE # Set = TRUE for numeric outcome
+  score_res <- get_scores_info_gain(score_obj, data, outcome)
+
+  y <- data[[outcome]]
+  X <- data[setdiff(names(data), outcome)]
+  fit <- FSelectorRcpp::information_gain(x = X, y = y)
+  exp.res <- fit$importance
+
+  expect_true(tibble::is_tibble(score_res))
+
+  expect_identical(nrow(score_res), ncol(data) - 1L)
+
+  expect_named(score_res, c("name", "score", "outcome", "predictor"))
+
+  expect_identical(score_res$score, exp.res)
+
+  expect_equal(unique(score_res$name), "infogain")
+
+  expect_equal(unique(score_res$outcome), "Sale_Price")
+})
+
+# TODO Test more after we add validators


### PR DESCRIPTION
This PR includes the following changes:

- Add `score_info_gain`
- Add `get_scores_info_gain`
- Fix `label = `for other filter methods