### PR TITLE
Default -log10(pval) for methods for aov, cross tab 

### DIFF
--- a/R/score-aov.R
+++ b/R/score-aov.R
@@ -30,7 +30,7 @@ score_aov <- function(
     deterministic = TRUE,
     tuning = FALSE,
     ties = NULL,
-    calculating_fn = get_single_f_stat,
+    calculating_fn = NULL,
     label = c(score_aov = "ANOVA F-statistics and p-values")
   )
 }
@@ -92,7 +92,6 @@ make_scores_aov <- function(score_type, score, outcome, predictors) {
 
 get_scores_aov <- function(score_obj, data, outcome) {
   if (score_obj$score_type == "fstat") {
-    # TODO Should I move this elsewhere?
     score_obj$calculating_fn <- get_single_f_stat
   } else if (score_obj$score_type == "pval") {
     score_obj$calculating_fn <- get_single_p_val
@@ -104,6 +103,15 @@ get_scores_aov <- function(score_obj, data, outcome) {
     purrr::set_names(predictors),
     \(x) map_score_aov(data, x, outcome, score_obj$calculating_fn)
   )
+
+  # Do we need score <- stats::p.adjust(score) here too?
+
+  if (
+    score_obj$score_type == "pval" &&
+      (is.null(score_obj$neg_log_pval) || isTRUE(score_obj$neg_log_pval))
+  ) {
+    score <- -log10(score)
+  }
 
   res <- make_scores_aov(score_obj$score_type, score, outcome, predictors)
   res

--- a/R/score-cross_tab.R
+++ b/R/score-cross_tab.R
@@ -1,7 +1,7 @@
 score_cross_tab <- function(
   range = c(0, 1),
   trans = NULL,
-  score_type = "pval_chisq",
+  score_type = "pval_chisq", # Move c() here later. Add validator. Document it.
   direction = "minimize"
 ) {
   new_score_obj(
@@ -43,11 +43,6 @@ map_score_cross_tab <- function(data, predictor, outcome, calculating_fn) {
   if (is.numeric(outcome_col) || is.numeric(predictor_col)) {
     return(NA_real_)
   }
-  # if (
-  #   length(levels(outcome_col)) > 2 || length(levels(predictor_col)) > 2
-  # ) {
-  #   return(NA_real_)
-  # }
 
   res <- calculating_fn(predictor_col, outcome_col)
   res

--- a/R/score-cross_tab.R
+++ b/R/score-cross_tab.R
@@ -1,7 +1,7 @@
 score_cross_tab <- function(
   range = c(0, 1),
   trans = NULL,
-  score_type = "chisq",
+  score_type = "pval_chisq",
   direction = "minimize"
 ) {
   new_score_obj(
@@ -12,7 +12,7 @@ score_cross_tab <- function(
     range = range,
     inclusive = c(TRUE, TRUE),
     fallback_value = 1,
-    score_type = score_type, # c("chisq", "fisher"),
+    score_type = score_type, # c("pval_chisq", "pval_fisher"),
     trans = NULL, # TODO
     sorts = NULL, # TODO
     direction = c("maximize", "minimize", "target"),
@@ -69,10 +69,9 @@ get_scores_cross_tab <- function(
   outcome,
   ... # i.e., score_obj$fdr
 ) {
-  if (score_obj$score_type == "chisq") {
-    # TODO Should I move this elsewhere?
+  if (score_obj$score_type == "pval_chisq") {
     score_obj$calculating_fn <- get_single_chisq
-  } else if (score_obj$score_type == "fisher") {
+  } else if (score_obj$score_type == "pval_fisher") {
     score_obj$calculating_fn <- get_single_fisher
   }
   predictors <- setdiff(names(data), outcome)
@@ -83,8 +82,11 @@ get_scores_cross_tab <- function(
   )
 
   if (score_obj$fdr == TRUE) {
-    # TODO Should I move this elsewhere?
     score <- stats::p.adjust(score)
+  }
+
+  if (is.null(score_obj$neg_log_pval) || isTRUE(score_obj$neg_log_pval)) {
+    score <- -log10(score)
   }
 
   res <- make_scores_cross_tab(score_obj$score_type, score, outcome, predictors)

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -411,6 +411,7 @@ fill_safe_values.default <- function(x) {
 #' score_obj_list |> fill_safe_values()
 #'
 fill_safe_values.list <- function(x) {
+  # TODO Max was saying maybe we can fill safe value as we merge in (PR #33)
   score_set <- bind_scores(x)
   for (i in 1:length(x)) {
     method_name <- x[[i]]$score_type
@@ -420,6 +421,8 @@ fill_safe_values.list <- function(x) {
   score_set
 }
 
-# TODO Filter *
-
 # TODO Drop outcome column
+
+# TODO filter_score_*
+# Looking ahead at the example in desiarbility2, I think we'd want
+# predictor, d_roc, d_fstat, d_pval, d_pearson, d_imp_rf, etc, d_all.

--- a/inst/example_ames.R
+++ b/inst/example_ames.R
@@ -139,6 +139,7 @@ score_obj_list |> bind_scores()
 #score_obj_list <- list(score_obj_aov, score_obj_aov) # TODO
 
 # Fill in safe values
+score_obj_list <- list(score_obj_aov, score_obj_cor, score_obj_imp)
 score_obj_list |> fill_safe_values()
 
 # TODO Filter *

--- a/tests/testthat/test-score-aov.R
+++ b/tests/testthat/test-score-aov.R
@@ -1,4 +1,4 @@
-test_that("get_scores_aov() is working", {
+test_that("get_scores_aov() is working for fstat", {
   skip_if_not_installed("modeldata")
   data(ames, package = "modeldata")
   data <- modeldata::ames |>
@@ -50,5 +50,111 @@ test_that("get_scores_aov() is working", {
 })
 
 # TODO Test Reversed stats::lm(x ~ y)
-# TODO Test pval
+# TODO Test -log10(pval)
+
+test_that("get_scores_aov() is working for -log10(pval)", {
+  skip_if_not_installed("modeldata")
+  data(ames, package = "modeldata")
+  data <- modeldata::ames |>
+    dplyr::select(
+      Sale_Price,
+      MS_SubClass,
+      MS_Zoning,
+      Lot_Frontage,
+      Lot_Area,
+      Street
+    )
+  outcome <- "Sale_Price"
+  score_obj = score_aov()
+  score_obj$score_type <- "pval"
+  score_res <- get_scores_aov(score_obj, data, outcome)
+
+  fit <- stats::lm(ames$Sale_Price ~ ames$MS_SubClass)
+  exp.MS_SubClass <- -log10(stats::anova(fit)$`Pr(>F)`[1])
+
+  fit <- stats::lm(ames$Sale_Price ~ ames$MS_Zoning)
+  exp.MS_Zoning <- -log10(stats::anova(fit)$`Pr(>F)`[1])
+
+  exp.Lot_Frontage <- NA
+
+  exp.Lot_Area <- NA
+
+  fit <- stats::lm(ames$Sale_Price ~ ames$Street)
+  exp.Street <- -log10(stats::anova(fit)$`Pr(>F)`[1])
+
+  expect_true(tibble::is_tibble(score_res))
+
+  expect_identical(nrow(score_res), ncol(data) - 1L)
+
+  expect_named(score_res, c("name", "score", "outcome", "predictor"))
+
+  expect_identical(
+    score_res$score,
+    c(
+      exp.MS_SubClass,
+      exp.MS_Zoning,
+      exp.Lot_Frontage,
+      exp.Lot_Area,
+      exp.Street
+    )
+  )
+
+  expect_equal(unique(score_res$name), "pval")
+
+  expect_equal(unique(score_res$outcome), "Sale_Price")
+})
+
+test_that("get_scores_aov() is working for pval", {
+  skip_if_not_installed("modeldata")
+  data(ames, package = "modeldata")
+  data <- modeldata::ames |>
+    dplyr::select(
+      Sale_Price,
+      MS_SubClass,
+      MS_Zoning,
+      Lot_Frontage,
+      Lot_Area,
+      Street
+    )
+  outcome <- "Sale_Price"
+  score_obj = score_aov()
+  score_obj$score_type <- "pval"
+  score_obj$neg_log_pval <- FALSE # Turn -log10() off
+  score_res <- get_scores_aov(score_obj, data, outcome)
+
+  fit <- stats::lm(ames$Sale_Price ~ ames$MS_SubClass)
+  exp.MS_SubClass <- stats::anova(fit)$`Pr(>F)`[1]
+
+  fit <- stats::lm(ames$Sale_Price ~ ames$MS_Zoning)
+  exp.MS_Zoning <- stats::anova(fit)$`Pr(>F)`[1]
+
+  exp.Lot_Frontage <- NA
+
+  exp.Lot_Area <- NA
+
+  fit <- stats::lm(ames$Sale_Price ~ ames$Street)
+  exp.Street <- stats::anova(fit)$`Pr(>F)`[1]
+
+  expect_true(tibble::is_tibble(score_res))
+
+  expect_identical(nrow(score_res), ncol(data) - 1L)
+
+  expect_named(score_res, c("name", "score", "outcome", "predictor"))
+
+  expect_identical(
+    score_res$score,
+    c(
+      exp.MS_SubClass,
+      exp.MS_Zoning,
+      exp.Lot_Frontage,
+      exp.Lot_Area,
+      exp.Street
+    )
+  )
+
+  expect_equal(unique(score_res$name), "pval")
+
+  expect_equal(unique(score_res$outcome), "Sale_Price")
+})
+
 # TODO Test more after we add validators

--- a/tests/testthat/test-score-cross_tab.R
+++ b/tests/testthat/test-score-cross_tab.R
@@ -1,21 +1,51 @@
-test_that("get_scores_cross_tab is working for chisq", {
+test_that("get_scores_cross_tab is working for -log10(chisq pval)", {
   library(titanic)
-  titanic_train$Survived <- titanic_train$Survived |> as.factor()
-  titanic_train$Pclass <- titanic_train$Pclass |> as.factor()
-  titanic_train$Sex <- titanic_train$Sex |> as.factor()
-  titanic_train$Embarked <- titanic_train$Embarked |> as.factor()
-  data <- tibble::tibble(
-    Survived = titanic_train$Survived,
-    Pclass = titanic_train$Pclass,
-    Sex = titanic_train$Sex,
-    Age = titanic_train$Age,
-    Fare = titanic_train$Fare,
-    Embarked = titanic_train$Embarked
-  )
+  titanic_train <- titanic_train %>%
+    dplyr::mutate(dplyr::across(c(Survived, Pclass, Sex, Embarked), as.factor))
+  data <- titanic_train %>%
+    dplyr::select(Survived, Pclass, Sex, Age, Fare, Embarked)
   outcome <- "Survived"
   score_obj <- score_cross_tab()
-  score_obj$score_type <- "chisq"
+  score_obj$score_type <- "pval_chisq"
   score_obj$fdr <- FALSE
+  score_res <- get_scores_cross_tab(score_obj, data, outcome)
+
+  exp.Pclass <- get_single_chisq(data$Pclass, data$Survived)
+  exp.Pclass <- -log10(exp.Pclass)
+  exp.Sex <- get_single_chisq(data$Sex, data$Survived)
+  exp.Sex <- -log10(exp.Sex)
+  exp.Age <- NA
+  exp.Fare <- NA
+  exp.Embarked <- get_single_chisq(data$Embarked, data$Survived)
+  exp.Embarked <- -log10(exp.Embarked)
+
+  expect_true(tibble::is_tibble(score_res))
+
+  expect_identical(nrow(score_res), ncol(data) - 1L)
+
+  expect_named(score_res, c("name", "score", "outcome", "predictor"))
+
+  expect_identical(
+    score_res$score,
+    c(exp.Pclass, exp.Sex, exp.Age, exp.Fare, exp.Embarked)
+  )
+
+  expect_equal(unique(score_res$name), "pval_chisq")
+
+  expect_equal(unique(score_res$outcome), "Survived")
+})
+
+test_that("get_scores_cross_tab is working for chisq pval", {
+  library(titanic)
+  titanic_train <- titanic_train %>%
+    dplyr::mutate(dplyr::across(c(Survived, Pclass, Sex, Embarked), as.factor))
+  data <- titanic_train %>%
+    dplyr::select(Survived, Pclass, Sex, Age, Fare, Embarked)
+  outcome <- "Survived"
+  score_obj <- score_cross_tab()
+  score_obj$score_type <- "pval_chisq"
+  score_obj$fdr <- FALSE
+  score_obj$neg_log_pval <- FALSE # Turn -log10() off
   score_res <- get_scores_cross_tab(score_obj, data, outcome)
 
   exp.Pclass <- get_single_chisq(data$Pclass, data$Survived)
@@ -35,30 +65,59 @@ test_that("get_scores_cross_tab is working for chisq", {
     c(exp.Pclass, exp.Sex, exp.Age, exp.Fare, exp.Embarked)
   )
 
-  expect_equal(unique(score_res$name), "chisq")
+  expect_equal(unique(score_res$name), "pval_chisq")
 
   expect_equal(unique(score_res$outcome), "Survived")
 })
 
-
-test_that("get_score_cross_tab is working for fisher", {
+test_that("get_score_cross_tab is working for -log10(fisher pval)", {
   library(titanic)
-  titanic_train$Survived <- titanic_train$Survived |> as.factor()
-  titanic_train$Pclass <- titanic_train$Pclass |> as.factor()
-  titanic_train$Sex <- titanic_train$Sex |> as.factor()
-  titanic_train$Embarked <- titanic_train$Embarked |> as.factor()
-  data <- tibble::tibble(
-    Survived = titanic_train$Survived,
-    Pclass = titanic_train$Pclass,
-    Sex = titanic_train$Sex,
-    Age = titanic_train$Age,
-    Fare = titanic_train$Fare,
-    Embarked = titanic_train$Embarked
-  )
+  titanic_train <- titanic_train %>%
+    dplyr::mutate(dplyr::across(c(Survived, Pclass, Sex, Embarked), as.factor))
+  data <- titanic_train %>%
+    dplyr::select(Survived, Pclass, Sex, Age, Fare, Embarked)
   outcome <- "Survived"
   score_obj <- score_cross_tab()
-  score_obj$score_type <- "fisher"
+  score_obj$score_type <- "pval_fisher"
   score_obj$fdr <- FALSE
+  score_res <- get_scores_cross_tab(score_obj, data, outcome)
+
+  exp.Pclass <- get_single_fisher(data$Pclass, data$Survived)
+  exp.Pclass <- -log10(exp.Pclass)
+  exp.Sex <- get_single_fisher(data$Sex, data$Survived)
+  exp.Sex <- -log10(exp.Sex)
+  exp.Age <- NA
+  exp.Fare <- NA
+  exp.Embarked <- get_single_fisher(data$Embarked, data$Survived)
+  exp.Embarked <- -log10(exp.Embarked)
+
+  expect_true(tibble::is_tibble(score_res))
+
+  expect_identical(nrow(score_res), ncol(data) - 1L)
+
+  expect_named(score_res, c("name", "score", "outcome", "predictor"))
+
+  expect_identical(
+    score_res$score,
+    c(exp.Pclass, exp.Sex, exp.Age, exp.Fare, exp.Embarked)
+  )
+
+  expect_equal(unique(score_res$name), "pval_fisher")
+
+  expect_equal(unique(score_res$outcome), "Survived")
+})
+
+test_that("get_score_cross_tab is working for fisher pval", {
+  library(titanic)
+  titanic_train <- titanic_train %>%
+    dplyr::mutate(dplyr::across(c(Survived, Pclass, Sex, Embarked), as.factor))
+  data <- titanic_train %>%
+    dplyr::select(Survived, Pclass, Sex, Age, Fare, Embarked)
+  outcome <- "Survived"
+  score_obj <- score_cross_tab()
+  score_obj$score_type <- "pval_fisher"
+  score_obj$fdr <- FALSE
+  score_obj$neg_log_pval <- FALSE # Turn -log10() off
   score_res <- get_scores_cross_tab(score_obj, data, outcome)
 
   exp.Pclass <- get_single_fisher(data$Pclass, data$Survived)
@@ -78,7 +137,7 @@ test_that("get_score_cross_tab is working for fisher", {
     c(exp.Pclass, exp.Sex, exp.Age, exp.Fare, exp.Embarked)
   )
 
-  expect_equal(unique(score_res$name), "fisher")
+  expect_equal(unique(score_res$name), "pval_fisher")
 
   expect_equal(unique(score_res$outcome), "Survived")
 })

--- a/tests/testthat/test-score-cross_tab.R
+++ b/tests/testthat/test-score-cross_tab.R
@@ -143,4 +143,5 @@ test_that("get_score_cross_tab is working for fisher pval", {
 })
 
 # TODO Test fdr
+# TODO Test multiclass
 # TODO Test more after we add validators


### PR DESCRIPTION
This PR includes the following changes: 

- Default `-log10(pval)` for aov, cross tab 
- User have to `score_obj$neg_log_pval <- FALSE` to turn `-log10()` off
- Rename `pval` to `pval_chisq`, `pval_fisher` to make it explicit 